### PR TITLE
Fix incorrect solver direction

### DIFF
--- a/lib/Solvers/Attachment.lua
+++ b/lib/Solvers/Attachment.lua
@@ -13,7 +13,7 @@ function solver:Solve(point: {[string]: any}): (Vector3, Vector3)
 	end
 
 	local origin: Vector3 = point.Instances[1].WorldPosition
-	local direction: Vector3 = point.Instances[1].WorldPosition - point.LastPosition
+	local direction: Vector3 = point.LastPosition - point.Instances[1].WorldPosition
 
 	return origin, direction
 end


### PR DESCRIPTION
This change corrects the inaccurate solver calculation of direction from the current attachment position to its previous position (currently it calculates the inverse direction leading to inaccuracy issues).