### PR TITLE
Added Shapecast support

### DIFF
--- a/lib/VisualizerCache.lua
+++ b/lib/VisualizerCache.lua
@@ -5,55 +5,96 @@
 -- Debug / Test ray visual options
 local DEFAULT_DEBUGGER_RAY_COLOUR: Color3 = Color3.fromRGB(255, 0, 0)
 local DEFAULT_DEBUGGER_RAY_WIDTH: number = 4
-local DEFAULT_DEBUGGER_RAY_NAME: string = "_RaycastHitboxDebugLine"
+local DEFAULT_DEBUGGER_RAY_NAME: string = "_RaycastHitboxDebug%s"
 local DEFAULT_FAR_AWAY_CFRAME: CFrame = CFrame.new(0, math.huge, 0)
 
 local cache = {}
 cache.__index = cache
 cache.__type = "RaycastHitboxVisualizerCache"
-cache._AdornmentInUse = {}
-cache._AdornmentInReserve = {}
+cache._AdornmentInUse = {
+	[1] = {},
+	[2] = {},
+	[3] = {},
+}
+cache._AdornmentInReserve = {
+	[1] = {},
+	[2] = {},
+	[3] = {},
+}
 
 --- AdornmentData type
 export type AdornmentData = {
-	Adornment: LineHandleAdornment,
+	Adornment: LineHandleAdornment | CylinderHandleAdornment | BoxHandleAdornment,
 	LastUse: number
 }
 
 --- Internal function to create an AdornmentData type
 --- Creates a LineHandleAdornment and a timer value
-function cache:_CreateAdornment(): AdornmentData
-	local line: LineHandleAdornment = Instance.new("LineHandleAdornment")
-	line.Name = DEFAULT_DEBUGGER_RAY_NAME
-	line.Color3 = DEFAULT_DEBUGGER_RAY_COLOUR
-	line.Thickness = DEFAULT_DEBUGGER_RAY_WIDTH
+function cache:_CreateAdornment(ShapecastMode: number): AdornmentData
+	if ShapecastMode == 1 then
+		local line: LineHandleAdornment = Instance.new("LineHandleAdornment")
+		line.Name = string.format(DEFAULT_DEBUGGER_RAY_NAME, "Line")
+		line.Color3 = DEFAULT_DEBUGGER_RAY_COLOUR
+		line.Thickness = DEFAULT_DEBUGGER_RAY_WIDTH
 
-	line.Length = 0
-	line.CFrame = DEFAULT_FAR_AWAY_CFRAME
+		line.Length = 0
+		line.CFrame = DEFAULT_FAR_AWAY_CFRAME
 
-	line.Adornee = workspace.Terrain
-	line.Parent = workspace.Terrain
+		line.Adornee = workspace.Terrain
+		line.Parent = workspace.Terrain
 
-	return {
-		Adornment = line,
-		LastUse = 0
-	}
+		return {
+			Adornment = line,
+			LastUse = 0
+		}
+	elseif ShapecastMode == 2 then
+		local cylinder: CylinderHandleAdornment = Instance.new("CylinderHandleAdornment")
+		cylinder.Name = string.format(DEFAULT_DEBUGGER_RAY_NAME, "Cylinder")
+		cylinder.Color3 = DEFAULT_DEBUGGER_RAY_COLOUR
+
+		cylinder.Radius = 0
+		cylinder.Height = 0
+		cylinder.CFrame = DEFAULT_FAR_AWAY_CFRAME
+
+		cylinder.Adornee = workspace.Terrain
+		cylinder.Parent = workspace.Terrain
+
+		return {
+			Adornment = cylinder,
+			LastUse = 0
+		}
+	elseif ShapecastMode == 3 then
+		local box: BoxHandleAdornment = Instance.new("BoxHandleAdornment")
+		box.Name = string.format(DEFAULT_DEBUGGER_RAY_NAME, "Box")
+		box.Color3 = DEFAULT_DEBUGGER_RAY_COLOUR
+
+		box.Size = Vector3.zero
+		box.CFrame = DEFAULT_FAR_AWAY_CFRAME
+
+		box.Adornee = workspace.Terrain
+		box.Parent = workspace.Terrain
+
+		return {
+			Adornment = box,
+			LastUse = 0
+		}
+	end
 end
 
 --- Gets an AdornmentData type. Creates one if there isn't one currently available.
-function cache:GetAdornment(): AdornmentData?
-	if #cache._AdornmentInReserve <= 0 then
+function cache:GetAdornment(ShapecastMode: number): AdornmentData?
+	if #cache._AdornmentInReserve[ShapecastMode] <= 0 then
 		--- Create a new LineAdornmentHandle if none are in reserve
-		local adornment: AdornmentData = cache:_CreateAdornment()
-		table.insert(cache._AdornmentInReserve, adornment)
+		local adornment: AdornmentData = cache:_CreateAdornment(ShapecastMode)
+		table.insert(cache._AdornmentInReserve[ShapecastMode], adornment)
 	end
 
-	local adornment: AdornmentData? = table.remove(cache._AdornmentInReserve, 1)
+	local adornment: AdornmentData? = table.remove(cache._AdornmentInReserve[ShapecastMode], 1)
 
 	if adornment then
 		adornment.Adornment.Visible = true
 		adornment.LastUse = os.clock()
-		table.insert(cache._AdornmentInUse, adornment)
+		table.insert(cache._AdornmentInUse[ShapecastMode], adornment)
 	end
 
 	return adornment
@@ -62,22 +103,36 @@ end
 --- Returns an AdornmentData back into the cache.
 -- @param AdornmentData
 function cache:ReturnAdornment(adornment: AdornmentData)
-	adornment.Adornment.Length = 0
+	local ShapecastMode: number = 1
+	if adornment.Adornment:IsA("LineHandleAdornment") then
+		adornment.Adornment.Length = 0
+		ShapecastMode = 1
+	elseif adornment.Adornment:IsA("CylinderHandleAdornment") then
+		adornment.Adornment.Radius = 0
+		adornment.Adornment.Height = 0
+		ShapecastMode = 2
+	elseif adornment.Adornment:IsA("BoxHandleAdornment") then
+		adornment.Adornment.Size = Vector3.zero
+		ShapecastMode = 3
+	end
+
 	adornment.Adornment.Visible = false
 	adornment.Adornment.CFrame = DEFAULT_FAR_AWAY_CFRAME
-	table.insert(cache._AdornmentInReserve, adornment)
+	table.insert(cache._AdornmentInReserve[ShapecastMode], adornment)
 end
 
 --- Clears the cache in reserve. Should only be used if you want to free up some memory.
 --- If you end up turning on the visualizer again for this session, the cache will fill up again.
 --- Does not clear adornments that are currently in use.
 function cache:Clear()
-	for i = #cache._AdornmentInReserve, 1, -1 do
-		if cache._AdornmentInReserve[i].Adornment then
-			cache._AdornmentInReserve[i].Adornment:Destroy()
-		end
+	for _, reserveCache in cache._AdornmentInReserve do
+		for i = #reserveCache, 1, -1 do
+			if reserveCache[i].Adornment then
+				reserveCache[i].Adornment:Destroy()
+			end
 
-		table.remove(cache._AdornmentInReserve, i)
+			table.remove(reserveCache, i)
+		end
 	end
 end
 

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -40,12 +40,13 @@ ________________________________________________________________________________
 
 			[ FUNCTIONS ]
 
-		* RaycastHitbox.new(Instance model | BasePart | nil)
+		* RaycastHitbox.new(Instance model | BasePart | nil, ShapecastMode number [1 - 3])
 				Description
 					--- Preps the model and recursively finds attachments in it so it knows where to shoot rays out of later. If a hitbox exists for this
 					--- object already, it simply returns the same hitbox.
 				Arguments
 					--- Instance:  (Like your character, a sword model, etc). Can be left nil in case you want an empty Hitbox or use SetPoints later
+					--- ShapecastMode:  Defaults to 1. Refer to ShapecastMode subsection below for more information
 				Returns
 					Instance HitboxObject
 						
@@ -130,7 +131,27 @@ ________________________________________________________________________________
 				Description
 					--- Defaults to 1. Refer to DetectionMode subsection below for more information
 
-			
+
+			[ SHAPECAST MODES ]
+
+		* RaycastHitbox.ShapecastMode.Line
+				Description
+					--- The classic Raycast method.
+					--- Casts a single line.
+
+		* RaycastHitbox.ShapecastMode.Sphere
+				Description
+					--- Uses the SphereCast method.
+					--- Casts a circle.
+					--- Hitbox.SphereCastRadius is used to set the radius for the SphereCast.
+
+		* RaycastHitbox.ShapecastMode.Block
+				Description
+					--- Uses the BlockCast method
+					--- Casts a cuboid.
+					--- Hitbox.BlockCastSize is used to set the radius for the BlockCast.
+		
+
 			[ DETECTION MODES ]
 
 		* RaycastHitbox.DetectionMode.Default
@@ -150,7 +171,6 @@ ________________________________________________________________________________
 					--- Similar to PartMode, the hitbox will return every hit part. Except, it will keep returning parts even if it has already hit them.
 					--- Warning: If you have multiple raycast or attachment points, each raycast will also call OnHit. Allows you to create your own
 					--- filter system.
-		
 ____________________________________________________________________________________________________________________________________________________________________________
 
 --]]
@@ -186,9 +206,16 @@ RaycastHitbox.SignalType = {
 	Single = 2, --- Defaults to Single connections only for legacy purposes
 }
 
+-- Shapecast mode enums
+RaycastHitbox.ShapecastMode = {
+	Line = 1,
+	Sphere = 2,
+	Block = 3,
+}
+
 --- Creates or finds a hitbox object. Returns an hitbox object
 -- @param required object parameter that takes in either a part or a model
-function RaycastHitbox.new(object: any?)
+function RaycastHitbox.new(object: any?, ShapecastMode: number?)
 	local hitbox: any
 
 	if object and CollectionService:HasTag(object, DEFAULT_COLLECTION_TAG_NAME) then
@@ -197,6 +224,11 @@ function RaycastHitbox.new(object: any?)
 		hitbox = setmetatable({
 			RaycastParams = nil,
 			DetectionMode = RaycastHitbox.DetectionMode.Default,
+			
+			_ShapecastMode = ShapecastMode or 1,
+			SphereCastRadius = 0,
+			BlockCastSize = Vector3.new(),
+
 			HitboxRaycastPoints = {},
 			HitboxPendingRemoval = false,
 			HitboxStopTime = 0,


### PR DESCRIPTION
- Added 3 new Enums (ShapecastModes): `Line`, `Sphere `and `Block`. Defaults to `Line`.
- `Hitbox.new()` now takes two arguments. The second argument being `ShapecastMode?`.
- Added two new properties: `SphereCastRadius` and `BlockCastSize`. Setting the properties wont affect the hitbox if the hitbox is not in the corresponding `ShapecastMode`.
- Made changes to `cache:_GetAdornment()` to check for the `ShapecastMode` and create corresponding HandleAdornments.
