### PR TITLE
Add 'raycast-hitbox' package to the Wally Package Manager

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -3,6 +3,7 @@ name = "Swordphin/raycast-hitbox"
 version = "4.0.1"
 realm = "shared"
 registry = "https://github.com/UpliftGames/wally-index"
+licence = "MIT"
 
 description = "raycast-hitbox is a hit detection system that utilizes Roblox's Raycasting APIs."
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,16 @@
+[package]
+name = "Swordphin/raycast-hitbox"
+version = "4.0.1"
+realm = "shared"
+registry = "https://github.com/UpliftGames/wally-index"
+
+description = "raycast-hitbox is a hit detection system that utilizes Roblox's Raycasting APIs."
+
+exclude = ["**"]
+include = ["lib", "lib/*", "default.project.json", "wally.toml", "LICENSE"]
+
+[dependencies]
+
+[server-dependencies]
+
+[dev-dependencies]

--- a/wally.toml
+++ b/wally.toml
@@ -4,6 +4,7 @@ version = "4.0.1"
 realm = "shared"
 registry = "https://github.com/UpliftGames/wally-index"
 licence = "MIT"
+authors = ["Swordphin"]
 
 description = "raycast-hitbox is a hit detection system that utilizes Roblox's Raycasting APIs."
 


### PR DESCRIPTION
## Context
I've noticed that there's no official package on the [Wally package manager](https://wally.run/) for this resource, this PR implements the required configuration files to get this package onto Wally!

