### PR TITLE
Update Attachment.lua: origin variable set incorrectly

### DIFF
--- a/lib/Solvers/Attachment.lua
+++ b/lib/Solvers/Attachment.lua
@@ -12,7 +12,7 @@ function solver:Solve(point: {[string]: any}): (Vector3, Vector3)
 		point.LastPosition = point.Instances[1].WorldPosition
 	end
 
-	local origin: Vector3 = point.Instances[1].WorldPosition
+	local origin: Vector3 = point.LastPosition
 	local direction: Vector3 = point.Instances[1].WorldPosition - point.LastPosition
 
 	return origin, direction


### PR DESCRIPTION
I had a bug were I was hitting the baseplate when I was nowhere lose to hitting it, along with the fact that my first set of "lines" after starting a hitbox never seem to register a hit. After I made the changes, those bugs disappeared.

PS: This is my first time using GitHub.